### PR TITLE
Add AssemblyInformationalVersion to let AppVeyor patch

### DIFF
--- a/src/Unity.Container.csproj
+++ b/src/Unity.Container.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <FileVersion>$(Version).0</FileVersion>
     <AssemblyVersion>$(Version).0</AssemblyVersion>
+    <AssemblyInformationalVersion>$(FileVersion)</AssemblyInformationalVersion>
     <PackageId>Unity.Container</PackageId>
     <Description>Unity Core Engine</Description>
     <Copyright>Copyright © Microsoft 2008</Copyright>


### PR DESCRIPTION
Latest release did not carry the info we set in #78; think this'll fix it in