### PR TITLE
Dedicated exception to handle failures of MakeGenericType exclusively

### DIFF
--- a/src/Policy/Mapping/GenericTypeBuildKeyMappingPolicy.cs
+++ b/src/Policy/Mapping/GenericTypeBuildKeyMappingPolicy.cs
@@ -65,7 +65,7 @@ namespace Unity.Policy.Mapping
             }
 
             Type[] genericArguments = targetTypeInfo.GenericTypeArguments;
-            Type resultType = Type.MakeGenericType(genericArguments);
+            Type resultType = MakeGenericTypeOrThrow(genericArguments);
             return new NamedTypeBuildKey(resultType, Name);
         }
 
@@ -73,6 +73,18 @@ namespace Unity.Policy.Mapping
         /// Instructs engine to resolve type rather than build it
         /// </summary>
         public bool RequireBuild { get; } = true;
+
+        private Type MakeGenericTypeOrThrow(Type[] genericArguments)
+        {
+            try
+            {
+                return Type.MakeGenericType(genericArguments);
+            }
+            catch (ArgumentException ae)
+            {
+                throw new MakeGenericTypeFailedException(ae);
+            }
+        }
 
         #endregion
     }

--- a/src/Policy/Mapping/MakeGenericTypeFailedException.cs
+++ b/src/Policy/Mapping/MakeGenericTypeFailedException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Unity.Policy.Mapping
+{
+    internal class MakeGenericTypeFailedException : Exception
+    {
+        public MakeGenericTypeFailedException(ArgumentException innerException)
+            : base("MakeGenericType failed", innerException)
+        {
+        }
+    }
+}

--- a/src/UnityContainer.Resolution.cs
+++ b/src/UnityContainer.Resolution.cs
@@ -149,10 +149,8 @@ namespace Unity
                 {
                     list.Add((T)((BuilderContext)context).NewBuildUp(typeof(T), registration.Name));
                 }
-                catch (ArgumentException ex)
+                catch (Policy.Mapping.MakeGenericTypeFailedException)
                 {
-                    if (!(ex.InnerException is TypeLoadException))
-                        throw;
                 }
             }
 

--- a/tests/Unity.Tests/Generics/GenericConstraintsFixture.cs
+++ b/tests/Unity.Tests/Generics/GenericConstraintsFixture.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Unity.Exceptions;
+
+namespace Unity.Tests.Generics
+{
+    [TestClass]
+    public class GenericConstraintsFixture
+    {
+        interface IFoo<T>
+        {
+        }
+
+        class Foo<T> : IFoo<T> where T : struct
+        {
+        }
+
+        [TestMethod]
+        public void ThrowsAppropriateExceptionWhenGenericArgumentFailsToMeetConstraintsOfMappedToType()
+        {
+            var ioc = new UnityContainer();
+
+            ioc.RegisterType(typeof(IFoo<>), typeof(Foo<>));
+
+            Assert.ThrowsException<ResolutionFailedException>(() => ioc.Resolve<IFoo<string>>());
+        }
+
+        [TestMethod]
+        public void CanResolveOpenGenericInterfaceWithConstraintsInMappedToTypeWhenConstraintsAreMet()
+        {
+            var ioc = new UnityContainer();
+
+            ioc.RegisterType(typeof(IFoo<>), typeof(Foo<>));
+
+            Assert.IsNotNull(ioc.Resolve<IFoo<int>>());
+        }
+    }
+}

--- a/tests/Unity.Tests/Issues/GitHub.cs
+++ b/tests/Unity.Tests/Issues/GitHub.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Unity.Lifetime;
 using Unity.Attributes;
+using Unity.Injection;
+using Unity.Exceptions;
 
 namespace Unity.Tests.Issues
 {
@@ -24,6 +26,18 @@ namespace Unity.Tests.Issues
 
             var value1 = ioc.CreateChildContainer().Resolve<IFoo>(new Resolution.ParameterOverride("view", "qq").OnType<Foo>());
             var value2 = ioc.CreateChildContainer().Resolve<IFoo>(new Resolution.ParameterOverride("view", "qq").OnType<Foo>());
+        }
+
+        [TestMethod]
+        public void unitycontainer_container_92()
+        {
+            var ioc = new UnityContainer();
+            ioc.RegisterType<IFoo>(
+                string.Empty, 
+                new SingletonLifetimeManager(), 
+                new InjectionFactory(c => { throw new InvalidOperationException(); }));
+
+            Assert.ThrowsException<ResolutionFailedException>(() => ioc.Resolve<IFoo>());
         }
 
         [TestMethod]


### PR DESCRIPTION
A small improvement for fix for #87 and #92 (done in https://github.com/unitycontainer/container/commit/941cdd6d7e41e976431763c511c466f0b26d309b)