### PR TITLE
#108: Added parametrized version of GetOrAdd, so child containers can…

### DIFF
--- a/src/UnityContainer.Implementation.cs
+++ b/src/UnityContainer.Implementation.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Unity.Builder;
 using Unity.Builder.Strategy;
 using Unity.Container;
@@ -112,7 +111,7 @@ namespace Unity
             _isTypeExplicitlyRegistered = IsTypeTypeExplicitlyRegisteredLocally;
 
             BuildUpPipeline = ThrowingBuildUp;
-            GetRegistration = GetOrAdd;
+            GetRegistration = (type, name) => GetOrAdd(type, name, CreateRegistration);
             Register = AddOrUpdate;
             GetPolicy = Get;
             SetPolicy = Set;
@@ -176,7 +175,7 @@ namespace Unity
             _isTypeExplicitlyRegistered = _parent._isTypeExplicitlyRegistered;
 
             BuildUpPipeline = _parent.BuildUpPipeline;
-            GetRegistration = _parent.GetRegistration;
+            GetRegistration = (type, name) => _parent.GetOrAdd(type, name, CreateRegistration);
             Register = CreateAndSetOrUpdate;
             GetPolicy = parent.GetPolicy;
             SetPolicy = CreateAndSetPolicy;

--- a/src/UnityContainer.Registration.cs
+++ b/src/UnityContainer.Registration.cs
@@ -398,7 +398,7 @@ namespace Unity
             }
         }
 
-        private IPolicySet GetOrAdd(Type type, string name)
+        private IPolicySet GetOrAdd(Type type, string name, Func<Type, string, IPolicySet> createRegistration)
         {
             var collisions = 0;
             var hashCode = (type?.GetHashCode() ?? 0) & 0x7FFFFFFF;
@@ -438,7 +438,7 @@ namespace Unity
                         _registrations.Entries[i].Value = existing;
                     }
 
-                    return existing.GetOrAdd(name, () => CreateRegistration(type, name));
+                    return existing.GetOrAdd(name, () => createRegistration(type, name));
                 }
 
                 if (_registrations.RequireToGrow || ListToHashCutoverPoint < collisions)
@@ -447,7 +447,7 @@ namespace Unity
                     targetBucket = hashCode % _registrations.Buckets.Length;
                 }
 
-                var registration = CreateRegistration(type, name);
+                var registration = createRegistration(type, name);
                 _registrations.Entries[_registrations.Count].HashCode = hashCode;
                 _registrations.Entries[_registrations.Count].Next = _registrations.Buckets[targetBucket];
                 _registrations.Entries[_registrations.Count].Key = type;
@@ -525,8 +525,6 @@ namespace Unity
                 _registrations.Count++;
                 return registration;
             }
-
-
         }
 
         private IPolicySet Get(Type type, string name)

--- a/src/UnityContainer.Resolution.cs
+++ b/src/UnityContainer.Resolution.cs
@@ -25,7 +25,7 @@ namespace Unity
 
             var info = type.GetTypeInfo();
             return !info.IsGenericType
-                ? _root.GetOrAdd(type, name)
+                ? _root.GetOrAdd(type, name, CreateRegistration)
                 : GetOrAddGeneric(type, name, info.GetGenericTypeDefinition());
         }
 


### PR DESCRIPTION
… pass up their own way of creating a new registration. This way child container strategies will be used when creating a build child for a new registration.