### PR TITLE
Added SetupChildBehaviors call for when strategies change (so it's co…

### DIFF
--- a/src/UnityContainer.Implementation.cs
+++ b/src/UnityContainer.Implementation.cs
@@ -268,6 +268,11 @@ namespace Unity
         {
             _strategyChain = new StrategyChain(_strategies);
             _buildChain = _strategies.ToArray();
+
+            if (null != _parent)
+            {
+                SetupChildContainerBehaviors();
+            }
         }
 
         private static void InstanceIsAssignable(Type assignmentTargetType, object assignmentInstance, string argumentName)

--- a/src/UnityContainer.Resolution.cs
+++ b/src/UnityContainer.Resolution.cs
@@ -24,9 +24,15 @@ namespace Unity
             if (null != registration) return registration;
 
             var info = type.GetTypeInfo();
-            return !info.IsGenericType
+
+            if (info.IsGenericType)
+            {
+                return GetOrAddGeneric(type, name, info.GetGenericTypeDefinition());
+            }
+
+            return _root.IsRegistered(type, name)
                 ? _root.GetOrAdd(type, name)
-                : GetOrAddGeneric(type, name, info.GetGenericTypeDefinition());
+                : GetOrAdd(type, name);
         }
 
         private static object ThrowingBuildUp(IBuilderContext context)

--- a/tests/Unity.Tests/ContainerRegistrationsFixture.cs
+++ b/tests/Unity.Tests/ContainerRegistrationsFixture.cs
@@ -1,0 +1,139 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Unity.Tests.v5.TestSupport;
+
+namespace Unity.Tests.v5
+{
+    [TestClass]
+    public class ContainerRegistrationsFixture
+    {
+        private IUnityContainer container;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            container = new UnityContainer();
+        }
+
+        [TestMethod]
+        public void ContainerListsItselfAsRegistered()
+        {
+            Assert.IsTrue(container.IsRegistered(typeof (IUnityContainer)));
+        }
+
+        [TestMethod]
+        public void ContainerDoesNotListItselfUnderNonDefaultName()
+        {
+            Assert.IsFalse(container.IsRegistered(typeof(IUnityContainer), "other"));
+        }
+
+        [TestMethod]
+        public void ContainerListsItselfAsRegisteredUsingGenericOverload()
+        {
+            Assert.IsTrue(container.IsRegistered<IUnityContainer>());
+        }
+
+        [TestMethod]
+        public void ContainerDoesNotListItselfUnderNonDefaultNameUsingGenericOverload()
+        {
+            Assert.IsFalse(container.IsRegistered<IUnityContainer>("other"));
+        }
+
+        [TestMethod]
+        public void IsRegisteredWorksForRegisteredType()
+        {
+            container.RegisterType<ILogger, MockLogger>();
+
+            Assert.IsTrue(container.IsRegistered<ILogger>());
+        }
+
+        [TestMethod]
+        public void ContainerIncludesItselfUnderRegistrations()
+        {
+            Assert.IsNotNull(container.Registrations.Where(r => r.RegisteredType == typeof(IUnityContainer)).FirstOrDefault());
+        }
+
+        [TestMethod]
+        public void NewRegistrationsShowUpInRegistrationsSequence()
+        {
+            container.RegisterType<ILogger, MockLogger>()
+                .RegisterType<ILogger, MockLogger>("second");
+
+            var registrations = (from r in container.Registrations
+                                 where r.RegisteredType == typeof (ILogger)
+                                 select r).ToList();
+
+            Assert.AreEqual(2, registrations.Count);
+
+            Assert.IsTrue(registrations.Any(r => r.Name == null));
+            Assert.IsTrue(registrations.Any(r => r.Name == "second"));
+        }
+
+        [TestMethod]
+        public void TypeMappingShowsUpInRegistrationsCorrectly()
+        {
+            container.RegisterType<ILogger, MockLogger>();
+
+            var registration =
+                (from r in container.Registrations where r.RegisteredType == typeof (ILogger) select r).First();
+            Assert.AreSame(typeof (MockLogger), registration.MappedToType);
+        }
+
+        [TestMethod]
+        public void NonMappingRegistrationShowsUpInRegistrationsSequence()
+        {
+            container.RegisterType<MockLogger>();
+            var registration = (from r in container.Registrations
+                                where r.RegisteredType == typeof (MockLogger)
+                                select r).First();
+
+            Assert.AreSame(registration.RegisteredType, registration.MappedToType);
+            Assert.IsNull(registration.Name);
+        }
+
+        [TestMethod]
+        public void RegistrationsInParentContainerAppearInChild()
+        {
+            container.RegisterType<ILogger, MockLogger>();
+            var child = container.CreateChildContainer();
+
+            var registration =
+                (from r in child.Registrations where r.RegisteredType == typeof (ILogger) select r).First();
+
+            Assert.AreSame(typeof (MockLogger), registration.MappedToType);
+        }
+
+        [TestMethod]
+        public void RegistrationsInChildContainerDoNotAppearInParent()
+        {
+            var child = container.CreateChildContainer()
+                .RegisterType<ILogger, MockLogger>("named");
+
+            var childRegistration = child.Registrations.Where(r => r.RegisteredType == typeof (ILogger)).First();
+            var parentRegistration =
+                container.Registrations.Where(r => r.RegisteredType == typeof (ILogger)).FirstOrDefault();
+
+            Assert.IsNull(parentRegistration);
+            Assert.IsNotNull(childRegistration);
+        }
+
+        [TestMethod]
+        public void DuplicateRegistrationsInParentAndChildOnlyShowUpOnceInChild()
+        {
+            container.RegisterType<ILogger, MockLogger>("one");
+
+            var child = container.CreateChildContainer()
+                .RegisterType<ILogger, SpecialLogger>("one");
+
+            var registrations = from r in child.Registrations
+                                where r.RegisteredType == typeof(ILogger)
+                                select r;
+
+            Assert.AreEqual(1, registrations.Count());
+
+            var childRegistration = registrations.First();
+            Assert.AreSame(typeof (SpecialLogger), childRegistration.MappedToType);
+            Assert.AreEqual("one", childRegistration.Name);
+        }
+    }
+}

--- a/tests/Unity.Tests/InjectionConstructorFixture.cs
+++ b/tests/Unity.Tests/InjectionConstructorFixture.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Unity.Builder;
+using Unity.Builder.Selection;
+using Unity.Injection;
+using Unity.Policy;
+using Unity.ResolverPolicy;
+using Unity.Tests.v5.TestSupport;
+
+namespace Unity.Tests.v5
+{
+    [TestClass]
+    public class InjectionConstructorFixture
+    {
+        [TestMethod]
+        public void InjectionConstructorInsertsChooserForDefaultConstructor()
+        {
+            var ctor = new InjectionConstructor();
+            var context = new MockBuilderContext
+                {
+                    BuildKey = new NamedTypeBuildKey(typeof (GuineaPig))
+                };
+            IPolicyList policies = context.PersistentPolicies;
+
+            ctor.AddPolicies(typeof(GuineaPig), policies);
+
+            var selector = policies.Get<IConstructorSelectorPolicy>(
+                new NamedTypeBuildKey(typeof(GuineaPig)));
+
+            SelectedConstructor selected = selector.SelectConstructor(context, policies);
+            Assert.AreEqual(typeof(GuineaPig).GetConstructor(new Type[0]), selected.Constructor);
+            Assert.AreEqual(0, selected.GetParameterResolvers().Length);
+        }
+
+        [TestMethod]
+        public void InjectionConstructorInsertsChooserForConstructorWithParameters()
+        {
+            string expectedString = "Hello";
+            int expectedInt = 12;
+
+            var ctor = new InjectionConstructor(expectedString, expectedInt);
+            var context = new MockBuilderContext
+                {
+                    BuildKey = new NamedTypeBuildKey(typeof (GuineaPig))
+                };
+            IPolicyList policies = context.PersistentPolicies;
+
+            ctor.AddPolicies(typeof(GuineaPig), policies);
+
+            var selector = policies.Get<IConstructorSelectorPolicy>(
+                new NamedTypeBuildKey(typeof(GuineaPig)));
+
+            SelectedConstructor selected = selector.SelectConstructor(context, policies);
+            var keys = selected.GetParameterResolvers();
+
+            Assert.AreEqual(typeof(GuineaPig).GetConstructor(Sequence.Collect(typeof(string), typeof(int))), selected.Constructor);
+            Assert.AreEqual(2, keys.Length);
+
+            Assert.AreEqual(expectedString, (string)keys[0].Resolve(context));
+            Assert.AreEqual(expectedInt, (int)keys[1].Resolve(context));
+        }
+
+        [TestMethod]
+        public void InjectionConstructorSetsResolverForInterfaceToLookupInContainer()
+        {
+            var ctor = new InjectionConstructor("Logger", typeof(ILogger));
+            var context = new MockBuilderContext();
+            context.BuildKey = new NamedTypeBuildKey(typeof(GuineaPig));
+            IPolicyList policies = context.PersistentPolicies;
+
+            ctor.AddPolicies(typeof(GuineaPig), policies);
+
+            var selector = policies.Get<IConstructorSelectorPolicy>(
+                new NamedTypeBuildKey(typeof(GuineaPig)));
+
+            SelectedConstructor selected = selector.SelectConstructor(context, policies);
+            var keys = selected.GetParameterResolvers();
+
+            Assert.AreEqual(typeof(GuineaPig).GetConstructor(Sequence.Collect(typeof(string), typeof(ILogger))), selected.Constructor);
+            Assert.AreEqual(2, keys.Length);
+
+            Assert.IsTrue(keys[1] is NamedTypeDependencyResolverPolicy);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void InjectionConstructorThrowsIfNoMatchingConstructor()
+        {
+            InjectionConstructor ctor = new InjectionConstructor(typeof(double));
+            var context = new MockBuilderContext();
+
+            ctor.AddPolicies(typeof(GuineaPig), context.PersistentPolicies);
+        }
+
+        private object ResolveValue(IPolicyList policies, string key)
+        {
+            IResolverPolicy resolver = policies.Get<IResolverPolicy>(key);
+            return resolver.Resolve(null);
+        }
+
+        private class GuineaPig
+        {
+            public GuineaPig()
+            {
+            }
+
+            public GuineaPig(int i)
+            {
+            }
+
+            public GuineaPig(string s)
+            {
+            }
+
+            public GuineaPig(int i, string s)
+            {
+            }
+
+            public GuineaPig(string s, int i)
+            {
+            }
+
+            public GuineaPig(string s, ILogger logger)
+            {
+            }
+        }
+    }
+}

--- a/tests/Unity.Tests/Issues/CodeplexIssuesFixture.cs
+++ b/tests/Unity.Tests/Issues/CodeplexIssuesFixture.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Unity.Attributes;
+using Unity.Injection;
+using Unity.Lifetime;
+
+namespace Unity.Tests.v5.Issues
+{
+    [TestClass]
+    public class CodeplexIssuesFixture
+    {
+        // http://www.codeplex.com/unity/WorkItem/View.aspx?WorkItemId=1307
+        [TestMethod]
+        public void InjectionConstructorWorksIfItIsFirstConstructor()
+        {
+            UnityContainer container = new UnityContainer();
+            container.RegisterType<IBasicInterface, ClassWithDoubleConstructor>();
+            IBasicInterface result = container.Resolve<IBasicInterface>();
+        }
+
+        // https://www.codeplex.com/Thread/View.aspx?ProjectName=unity&ThreadId=25301
+        [TestMethod]
+        public void CanUseNonDefaultLifetimeManagerWithOpenGenericRegistration()
+        {
+            IUnityContainer container = new UnityContainer();
+            container.RegisterType(typeof(ISomeInterface<>),
+                typeof(MyTypeImplementingSomeInterface<>),
+                new ContainerControlledLifetimeManager());
+            ISomeInterface<int> intSomeInterface = container.Resolve<ISomeInterface<int>>();
+            ISomeInterface<string> stringObj1 = container.Resolve<ISomeInterface<string>>();
+            ISomeInterface<string> stringObj2 = container.Resolve<ISomeInterface<string>>();
+
+            Assert.AreSame(stringObj1, stringObj2);
+        }
+
+        // https://www.codeplex.com/Thread/View.aspx?ProjectName=unity&ThreadId=25301
+        [TestMethod]
+        public void CanOverrideGenericLifetimeManagerWithSpecificOne()
+        {
+            IUnityContainer container = new UnityContainer()
+                .RegisterType(typeof(ISomeInterface<>),
+                    typeof(MyTypeImplementingSomeInterface<>),
+                    new ContainerControlledLifetimeManager())
+                .RegisterType(typeof(ISomeInterface<double>), typeof(MyTypeImplementingSomeInterface<double>), new TransientLifetimeManager());
+
+            ISomeInterface<string> string1 = container.Resolve<ISomeInterface<string>>();
+            ISomeInterface<string> string2 = container.Resolve<ISomeInterface<string>>();
+
+            ISomeInterface<double> double1 = container.Resolve<ISomeInterface<double>>();
+            ISomeInterface<double> double2 = container.Resolve<ISomeInterface<double>>();
+
+            Assert.AreSame(string1, string2);
+            Assert.AreNotSame(double1, double2);
+        }
+
+        // https://www.codeplex.com/Thread/View.aspx?ProjectName=unity&ThreadId=26318
+        [TestMethod]
+        public void RegisteringInstanceInChildOverridesRegisterTypeInParent()
+        {
+            IUnityContainer container = new UnityContainer()
+                .RegisterType<IBasicInterface, ClassWithDoubleConstructor>(new ContainerControlledLifetimeManager());
+
+            IUnityContainer child = container.CreateChildContainer()
+                .RegisterInstance<IBasicInterface>(new MockBasic());
+
+            IBasicInterface result = child.Resolve<IBasicInterface>();
+
+            Assert.IsInstanceOfType(result, typeof(MockBasic));
+        }
+
+        // http://www.codeplex.com/unity/Thread/View.aspx?ThreadId=30292
+        [TestMethod]
+        public void CanConfigureGenericDictionaryForInjectionUsingRegisterType()
+        {
+            IUnityContainer container = new UnityContainer()
+                .RegisterType(typeof(IDictionary<,>), typeof(Dictionary<,>),
+                    new InjectionConstructor());
+
+            IDictionary<string, string> result = container.Resolve<IDictionary<string, string>>();
+        }
+
+        // http://unity.codeplex.com/WorkItem/View.aspx?WorkItemId=6431
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void AccessViolationExceptionOnx64()
+        {
+            var container1 = new UnityContainer();
+            container1.RegisterType<InnerX64Class>();
+            // SomeProperty is static, this should throw here
+            container1.RegisterType<OuterX64Class>(new InjectionProperty("SomeProperty"));
+        }
+
+        // http://unity.codeplex.com/WorkItem/View.aspx?WorkItemId=6491
+        [TestMethod]
+        public void CanResolveTimespan()
+        {
+            var container = new UnityContainer()
+                .RegisterType<TimeSpan>(new ExternallyControlledLifetimeManager(),
+                new InjectionConstructor(0L));
+            var expected = new TimeSpan();
+            var result = container.Resolve<TimeSpan>();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        // http://unity.codeplex.com/WorkItem/View.aspx?WorkItemId=6053
+        [TestMethod]
+        public void ResolveAllWithChildDoesNotRepeatOverriddenRegistrations()
+        {
+            var parent = new UnityContainer()
+                .RegisterInstance("str1", "string1")
+                .RegisterInstance("str2", "string2");
+
+            var child = parent.CreateChildContainer()
+                .RegisterInstance("str2", "string20")
+                .RegisterInstance("str3", "string30");
+
+            var result = child.ResolveAll<string>();
+
+            CollectionAssert.AreEquivalent(new[] { "string1", "string20", "string30" }, result.ToArray());
+        }
+
+        // http://unity.codeplex.com/WorkItem/View.aspx?WorkItemId=6997
+        [TestMethod]
+        public void IsRegisteredReturnsCorrectValue()
+        {
+            IUnityContainer container = new UnityContainer();
+            container.RegisterType<MyClass>(new InjectionConstructor("Name"));
+            var inst = container.Resolve<MyClass>();
+            Assert.IsTrue(container.IsRegistered<MyClass>());
+        }
+
+        // http://unity.codeplex.com/WorkItem/View.aspx?WorkItemId=3392
+        [TestMethod]
+        public void ResolveAllResolvesOpenGeneric()
+        {
+            IUnityContainer container = new UnityContainer()
+                .RegisterType(typeof (ISomeInterface<>), typeof (MyTypeImplementingSomeInterface<>), "open")
+                .RegisterType<ISomeInterface<string>, MyTypeImplementingSomeInterfaceOfString>("string");
+
+            var results = container.ResolveAll<ISomeInterface<string>>().ToList();
+
+            Assert.AreEqual(2, results.Count());
+            
+            CollectionAssert.AreEquivalent(
+                new[] { typeof(MyTypeImplementingSomeInterface<string>), typeof(MyTypeImplementingSomeInterfaceOfString) },
+                results.Select(o => o.GetType()).ToArray());
+        }
+
+        // http://unity.codeplex.com/WorkItem/View.aspx?WorkItemId=6999
+        [TestMethod]
+        public void ContainerControlledOpenGenericInParentResolvesProperlyInChild()
+        {
+            IUnityContainer parentContainer = new UnityContainer()
+                .RegisterType(typeof (ISomeInterface<>), typeof (MyTypeImplementingSomeInterface<>), new ContainerControlledLifetimeManager());
+
+            var childOneObject = parentContainer.CreateChildContainer().Resolve<ISomeInterface<string>>();
+            var childTwoObject = parentContainer.CreateChildContainer().Resolve<ISomeInterface<string>>();
+
+            Assert.AreSame(childOneObject, childTwoObject);
+        }
+
+        public interface IBasicInterface
+        { 
+        }
+
+        public class ClassWithDoubleConstructor : IBasicInterface
+        {
+            private string myString = "";
+
+            [InjectionConstructor]
+            public ClassWithDoubleConstructor()
+                : this(string.Empty)
+            {
+            }
+
+            public ClassWithDoubleConstructor(string myString)
+            {
+                this.myString = myString;
+            }
+        }
+
+        public interface ISomeInterface<T>
+        {
+        }
+
+        public class MyTypeImplementingSomeInterface<T> : ISomeInterface<T>
+        {
+        }
+
+        public class MyTypeImplementingSomeInterfaceOfString : ISomeInterface<string>
+        {
+        }
+
+        public class MockBasic : IBasicInterface
+        {
+        }
+
+        public class InnerX64Class
+        {
+        }
+
+        public class OuterX64Class
+        {
+            public static InnerX64Class SomeProperty { get; set; }
+        }
+
+        public class MyClass
+        {
+            public string Name { get; set; }
+
+            public MyClass()
+            {
+            }
+            public MyClass(string name)
+            {
+                Name = name;
+            }
+        }
+    }
+}

--- a/tests/Unity.Tests/Issues/GitHub.cs
+++ b/tests/Unity.Tests/Issues/GitHub.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Diagnostics;
+using Microsoft.Practices.Unity.Tests.TestObjects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Unity.Attributes;
+using Unity.Builder;
 using Unity.Exceptions;
 using Unity.Injection;
 using Unity.Lifetime;
+using Unity.Tests.TestObjects;
 
 namespace Unity.Tests.v5.Issues
 {
@@ -24,6 +27,48 @@ namespace Unity.Tests.v5.Issues
             {
                 View = view;
             }
+        }
+
+        [TestMethod]
+        public void unitycontainer_container_108_without_any_registrations()
+        {
+            var ioc = new UnityContainer();
+            var child = ioc.CreateChildContainer();
+            var spyStrategy = new TestDoubles.SpyStrategy();
+            child.AddExtension(new TestDoubles.SpyExtension(spyStrategy, UnityBuildStage.PreCreation));
+
+            child.Resolve<EmailService>();
+
+            Assert.AreEqual(typeof(EmailService), spyStrategy.BuildKey.Type);
+        }
+
+        [TestMethod]
+        public void unitycontainer_container_108_with_some_existing_registration()
+        {
+            var ioc = new UnityContainer();
+            var child = ioc.CreateChildContainer();
+            var spyStrategy = new TestDoubles.SpyStrategy();
+            child.AddExtension(new TestDoubles.SpyExtension(spyStrategy, UnityBuildStage.PreCreation));
+
+            child.RegisterType<IService, EmailService>();
+            child.Resolve<IService>();
+            child.Resolve<EmailService>();
+
+            Assert.AreEqual(typeof(EmailService), spyStrategy.BuildKey.Type);
+        }
+
+        [TestMethod]
+        public void unitycontainer_container_108_for_dependencies()
+        {
+            var child = new UnityContainer().CreateChildContainer();
+            var spyStrategy = new TestDoubles.SpyStrategy();
+            child.AddExtension(new TestDoubles.SpyExtension(spyStrategy, UnityBuildStage.PreCreation));
+
+            child.RegisterType<ObjectWithOneDependency, ObjectWithOneDependency>();
+            child.Resolve<ObjectWithOneDependency>();
+
+            var innerDependencyType = typeof(object);
+            Assert.AreEqual(innerDependencyType, spyStrategy.BuildKey.Type);
         }
 
         [TestMethod]

--- a/tests/Unity.Tests/TestDoubles/SpyExtension.cs
+++ b/tests/Unity.Tests/TestDoubles/SpyExtension.cs
@@ -34,7 +34,11 @@ namespace Unity.Tests.v5.TestDoubles
         protected override void Initialize()
         {
             Context.Strategies.Add(this.strategy, this.stage);
-            Context.Policies.Set(null, null, this.policyType, this.policy);
+
+            if (this.policy != null)
+            {
+                Context.Policies.Set(null, null, this.policyType, this.policy);
+            }
         }
     }
 }

--- a/tests/Unity.Tests/TestDoubles/SpyStrategy.cs
+++ b/tests/Unity.Tests/TestDoubles/SpyStrategy.cs
@@ -4,57 +4,37 @@ using Unity.Policy;
 
 namespace Unity.Tests.v5.TestDoubles
 {
-    /// <summary>
-    /// A small noop strategy that lets us check afterwards to
-    /// see if it ran in the strategy chain.
-    /// </summary>
     internal class SpyStrategy : BuilderStrategy
     {
-        private IBuilderContext context = null;
-        private object buildKey = null;
-        private object existing = null;
-        private bool buildUpWasCalled = false;
-
         public override void PreBuildUp(IBuilderContext context)
         {
-            this.buildUpWasCalled = true;
-            this.context = context;
-            this.buildKey = context.BuildKey;
-            this.existing = context.Existing;
+            this.BuildUpWasCalled = true;
+            this.Context = context;
+            this.BuildKey = context.BuildKey;
+            this.Existing = context.Existing;
 
             this.UpdateSpyPolicy(context);
         }
 
         public override void PostBuildUp(IBuilderContext context)
         {
-            this.existing = context.Existing;
+            this.Existing = context.Existing;
         }
 
-        public IBuilderContext Context
-        {
-            get { return this.context; }
-        }
+        public IBuilderContext Context { get; private set; }
 
-        public object BuildKey
-        {
-            get { return this.buildKey; }
-        }
+        public INamedType BuildKey { get; private set; }
 
-        public object Existing
-        {
-            get { return this.existing; }
-        }
+        public object Existing { get; private set; }
 
-        public bool BuildUpWasCalled
-        {
-            get { return this.buildUpWasCalled; }
-        }
+        public bool BuildUpWasCalled { get; private set; }
 
         private void UpdateSpyPolicy(IBuilderContext context)
         {
-            SpyPolicy policy = (SpyPolicy)context.Policies
-                                                 .GetOrDefault(typeof(SpyPolicy), 
-                                                         context.BuildKey, out _);
+            var policy = (SpyPolicy)context
+                .Policies
+                .GetOrDefault(typeof(SpyPolicy), context.BuildKey, out _);
+
             if (policy != null)
             {
                 policy.WasSpiedOn = true;

--- a/tests/Unity.Tests/UnityContainerFixture.cs
+++ b/tests/Unity.Tests/UnityContainerFixture.cs
@@ -1,0 +1,727 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Practices.Unity.Tests.TestObjects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Unity;
+using Unity.Attributes;
+using Unity.Builder;
+using Unity.Builder.Strategy;
+using Unity.Exceptions;
+using Unity.Extension;
+using Unity.Injection;
+using Unity.Lifetime;
+using Unity.Tests.v5.TestObjects;
+using Unity.Tests.v5.TestSupport;
+
+namespace Unity.Tests.v5
+{
+    [TestClass]
+    public class UnityContainerFixture
+    {
+        [TestMethod]
+        public void CanCreateObjectFromUnconfiguredContainer()
+        {
+            var container = new UnityContainer();
+
+            object o = container.Resolve<object>();
+
+            Assert.IsNotNull(o);
+        }
+
+        [TestMethod]
+        public void ContainerResolvesRecursiveConstructorDependencies()
+        {
+            var container = new UnityContainer();
+            var dep = container.Resolve<ObjectWithOneDependency>();
+
+            Assert.IsNotNull(dep);
+            Assert.IsNotNull(dep.InnerObject);
+            Assert.AreNotSame(dep, dep.InnerObject);
+        }
+
+        [TestMethod]
+        public void ContainerResolvesMultipleRecursiveConstructorDependencies()
+        {
+            var container = new UnityContainer();
+            var dep = container.Resolve<ObjectWithTwoConstructorDependencies>();
+
+            dep.Validate();
+        }
+
+        [TestMethod]
+        public void CanResolveTypeMapping()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>();
+
+            var logger = container.Resolve<ILogger>();
+
+            Assert.IsNotNull(logger);
+            Assert.IsInstanceOfType(logger, typeof(MockLogger));
+        }
+
+        [TestMethod]
+        public void CanRegisterTypeMappingsWithNames()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>()
+                .RegisterType<ILogger, SpecialLogger>("special");
+
+            var defaultLogger = container.Resolve<ILogger>();
+            var specialLogger = container.Resolve<ILogger>("special");
+
+            Assert.IsNotNull(defaultLogger);
+            Assert.IsNotNull(specialLogger);
+
+            Assert.IsInstanceOfType(defaultLogger, typeof(MockLogger));
+            Assert.IsInstanceOfType(specialLogger, typeof(SpecialLogger));
+        }
+
+        [TestMethod]
+        public void ShouldDoPropertyInjection()
+        {
+            var container = new UnityContainer();
+
+            var obj = container.Resolve<ObjectWithTwoProperties>();
+
+            obj.Validate();
+        }
+
+        [TestMethod]
+        public void ShouldSkipIndexers()
+        {
+            var container = new UnityContainer();
+
+            var obj = container.Resolve<ObjectWithIndexer>();
+
+            obj.Validate();
+        }
+
+        [TestMethod]
+        public void ShouldDoAllInjections()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>();
+
+            var obj = container.Resolve<ObjectWithLotsOfDependencies>();
+
+            Assert.IsNotNull(obj);
+            obj.Validate();
+        }
+
+        [TestMethod]
+        public void CanGetObjectsUsingNongenericMethod()
+        {
+            IUnityContainer container = new UnityContainer()
+                .RegisterType(typeof(ILogger), typeof(MockLogger));
+
+            var logger = container.Resolve(typeof(ILogger));
+
+            Assert.IsNotNull(logger);
+            Assert.IsInstanceOfType(logger, typeof(MockLogger));
+        }
+
+        [TestMethod]
+        public void CanGetNamedObjectsUsingNongenericMethod()
+        {
+            var container = new UnityContainer()
+                .RegisterType(typeof(ILogger), typeof(MockLogger))
+                .RegisterType(typeof(ILogger), typeof(SpecialLogger), "special");
+
+            var defaultLogger = container.Resolve(typeof(ILogger)) as ILogger;
+            var specialLogger = container.Resolve(typeof(ILogger), "special") as ILogger;
+
+            Assert.IsNotNull(defaultLogger);
+            Assert.IsNotNull(specialLogger);
+
+            Assert.IsInstanceOfType(defaultLogger, typeof(MockLogger));
+            Assert.IsInstanceOfType(specialLogger, typeof(SpecialLogger));
+        }
+
+        [TestMethod]
+        public void AllInjectionsWorkFromNongenericMethods()
+        {
+            var container = new UnityContainer()
+                .RegisterType(typeof(ILogger), typeof(MockLogger));
+
+            var obj = (ObjectWithLotsOfDependencies)container.Resolve(typeof(ObjectWithLotsOfDependencies));
+            obj.Validate();
+        }
+
+        [TestMethod]
+        public void ContainerSupportsSingletons()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>(new ContainerControlledLifetimeManager());
+
+            var logger1 = container.Resolve<ILogger>();
+            var logger2 = container.Resolve<ILogger>();
+
+            Assert.IsInstanceOfType(logger1, typeof(MockLogger));
+            Assert.AreSame(logger1, logger2);
+        }
+
+        [TestMethod]
+        public void CanCreatedNamedSingletons()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>()
+                .RegisterType<ILogger, SpecialLogger>("special", new ContainerControlledLifetimeManager());
+
+            var logger1 = container.Resolve<ILogger>();
+            var logger2 = container.Resolve<ILogger>();
+            var logger3 = container.Resolve<ILogger>("special");
+            var logger4 = container.Resolve<ILogger>("special");
+
+            Assert.AreNotSame(logger1, logger2);
+            Assert.AreSame(logger3, logger4);
+        }
+
+        [TestMethod]
+        public void CanRegisterSingletonsWithNongenericMethods()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>(new ContainerControlledLifetimeManager())
+                .RegisterType<ILogger, SpecialLogger>("special", new ContainerControlledLifetimeManager());
+
+            var logger1 = container.Resolve<ILogger>();
+            var logger2 = container.Resolve<ILogger>();
+            var logger3 = container.Resolve<ILogger>("special");
+            var logger4 = container.Resolve<ILogger>("special");
+
+            Assert.AreSame(logger1, logger2);
+            Assert.AreSame(logger3, logger4);
+            Assert.AreNotSame(logger1, logger3);
+        }
+
+        [TestMethod]
+        public void DisposingContainerDisposesSingletons()
+        {
+            var container = new UnityContainer()
+                .RegisterType<DisposableObject>(new ContainerControlledLifetimeManager());
+
+            var dobj = container.Resolve<DisposableObject>();
+
+            Assert.IsFalse(dobj.WasDisposed);
+            container.Dispose();
+
+            Assert.IsTrue(dobj.WasDisposed);
+        }
+
+        [TestMethod]
+        public void SingletonsRegisteredAsDefaultGetInjected()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ObjectWithOneDependency>(new ContainerControlledLifetimeManager());
+
+            var dep = container.Resolve<ObjectWithOneDependency>();
+            var dep2 = container.Resolve<ObjectWithTwoConstructorDependencies>();
+
+            Assert.AreSame(dep, dep2.OneDep);
+        }
+
+        [TestMethod]
+        public void CanDoInjectionOnExistingObjects()
+        {
+            var container = new UnityContainer();
+
+            var o = new ObjectWithTwoProperties();
+            
+            Assert.IsNull(o.Obj1);
+            Assert.IsNull(o.Obj2);
+
+            container.BuildUp(o);
+
+            o.Validate();
+        }
+
+        [TestMethod]
+        public void CanBuildUpExistingObjectWithNonGenericObject()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>();
+
+            var o = new ObjectUsingLogger();
+            var result = container.BuildUp(o);
+
+            Assert.IsInstanceOfType(result, typeof(ObjectUsingLogger));
+            Assert.AreSame(o, result);
+            Assert.IsNotNull(o.Logger);
+            Assert.IsInstanceOfType(o.Logger, typeof(MockLogger));
+        }
+
+        [TestMethod]
+        public void CanBuildupObjectWithExplicitInterface()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>();
+
+            var o = new ObjectWithExplicitInterface();
+            container.BuildUp<ISomeCommonProperties>(o);
+
+            o.ValidateInterface();
+        }
+
+        [TestMethod]
+        public void CanBuildupObjectWithExplicitInterfaceUsingNongenericMethod()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>();
+
+            var o = new ObjectWithExplicitInterface();
+            container.BuildUp(typeof(ISomeCommonProperties), o);
+
+            o.ValidateInterface();
+
+        }
+
+        [TestMethod]
+        public void CanUseInstanceAsSingleton()
+        {
+            var logger = new MockLogger();
+
+            var container = new UnityContainer()
+                .RegisterInstance(typeof(ILogger), "logger", logger, new ContainerControlledLifetimeManager());
+
+            var o = container.Resolve<ILogger>("logger");
+            Assert.AreSame(logger, o);
+        }
+
+
+        [TestMethod]
+        public void CanUseInstanceAsSingletonViaGenericMethod()
+        {
+            var logger = new MockLogger();
+
+            var container = new UnityContainer()
+                .RegisterInstance<ILogger>("logger", logger);
+
+            var o = container.Resolve<ILogger>("logger");
+            Assert.AreSame(logger, o);
+        }
+
+        [TestMethod]
+        public void DisposingContainerDisposesOwnedInstances()
+        {
+            var o = new DisposableObject();
+            var container = new UnityContainer()
+                .RegisterInstance(typeof(object), o);
+
+            container.Dispose();
+            Assert.IsTrue(o.WasDisposed);
+        }
+
+        [TestMethod]
+        public void DisposingContainerDoesNotDisposeUnownedInstances()
+        {
+            var o = new DisposableObject();
+            var container = new UnityContainer()
+                .RegisterInstance(typeof(object), o, new ExternallyControlledLifetimeManager());
+
+            container.Dispose();
+            Assert.IsFalse(o.WasDisposed);
+            GC.KeepAlive(o);
+        }
+
+        [TestMethod]
+        public void ContainerDefaultsToInstanceOwnership()
+        {
+            var o = new DisposableObject();
+            var container = new UnityContainer()
+                .RegisterInstance(typeof(object), o);
+            container.Dispose();
+            Assert.IsTrue(o.WasDisposed);
+        }
+
+        [TestMethod]
+        public void ContainerDefaultsToInstanceOwnershipViaGenericMethod()
+        {
+            var o = new DisposableObject();
+            var container = new UnityContainer()
+                .RegisterInstance(typeof(DisposableObject), o);
+            container.Dispose();
+            Assert.IsTrue(o.WasDisposed);
+        }
+
+        [TestMethod]
+        public void InstanceRegistrationWithoutNameRegistersDefault()
+        {
+            var l = new MockLogger();
+            var container = new UnityContainer()
+                .RegisterInstance(typeof(ILogger), l);
+
+            var o = container.Resolve<ILogger>();
+            Assert.AreSame(l, o);
+        }
+
+        [TestMethod]
+        public void InstanceRegistrationWithoutNameRegistersDefaultViaGenericMethod()
+        {
+            var l = new MockLogger();
+            var container = new UnityContainer()
+                .RegisterInstance<ILogger>(l);
+
+            var o = container.Resolve<ILogger>();
+            Assert.AreSame(l, o);
+        }
+
+        [TestMethod]
+        public void CanRegisterDefaultInstanceWithoutLifetime()
+        {
+            var o = new DisposableObject();
+
+            var container = new UnityContainer()
+                .RegisterInstance(typeof(object), o, new ExternallyControlledLifetimeManager());
+
+            var result = container.Resolve<object>();
+            Assert.IsNotNull(result);
+            Assert.AreSame(o, result);
+
+            container.Dispose();
+            Assert.IsFalse(o.WasDisposed);
+            GC.KeepAlive(o);
+        }
+
+        [TestMethod]
+        public void CanRegisterDefaultInstanceWithoutLifetimeViaGenericMethod()
+        {
+            var o = new DisposableObject();
+
+            var container = new UnityContainer()
+                .RegisterInstance<object>(o, new ExternallyControlledLifetimeManager());
+
+            object result = container.Resolve<object>();
+            Assert.IsNotNull(result);
+            Assert.AreSame(o, result);
+
+            container.Dispose();
+            Assert.IsFalse(o.WasDisposed);
+            GC.KeepAlive(o);
+        }
+
+        [TestMethod]
+        public void CanSpecifyInjectionConstructorWithDefaultDependencies()
+        {
+            string sampleString = "Hi there";
+            var container = new UnityContainer()
+                .RegisterInstance(sampleString);
+
+            var o = container.Resolve<ObjectWithInjectionConstructor>();
+
+            Assert.IsNotNull(o.ConstructorDependency);
+            Assert.AreSame(sampleString, o.ConstructorDependency);
+        }
+
+        [TestMethod]
+        public void CanGetInstancesOfAllRegisteredTypes()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>("mock")
+                .RegisterType<ILogger, SpecialLogger>("special")
+                .RegisterType<ILogger, MockLogger>("another");
+
+            List<ILogger> loggers = new List<ILogger>(
+                container.ResolveAll<ILogger>());
+
+            Assert.AreEqual(3, loggers.Count);
+            Assert.IsInstanceOfType(loggers[0], typeof(MockLogger));
+            Assert.IsInstanceOfType(loggers[1], typeof(SpecialLogger));
+            Assert.IsInstanceOfType(loggers[2], typeof(MockLogger));
+        }
+
+        [TestMethod]
+        public void GetAllDoesNotReturnTheDefault()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, SpecialLogger>("special")
+                .RegisterType<ILogger, MockLogger>();
+
+            var loggers = container.ResolveAll<ILogger>().ToList();
+
+            Assert.AreEqual(1, loggers.Count);
+            Assert.IsInstanceOfType(loggers[0], typeof(SpecialLogger));
+        }
+
+        [TestMethod]
+        public void CanGetAllWithNonGenericMethod()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>("mock")
+                .RegisterType<ILogger, SpecialLogger>("special")
+                .RegisterType<ILogger, MockLogger>("another");
+
+            var loggers = container.ResolveAll(typeof(ILogger)).ToList();
+
+            Assert.AreEqual(3, loggers.Count);
+            Assert.IsInstanceOfType(loggers[0], typeof(MockLogger));
+            Assert.IsInstanceOfType(loggers[1], typeof(SpecialLogger));
+            Assert.IsInstanceOfType(loggers[2], typeof(MockLogger));
+        }
+
+        [TestMethod]
+        public void GetAllReturnsRegisteredInstances()
+        {
+            var l = new MockLogger();
+
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>("normal")
+                .RegisterType<ILogger, SpecialLogger>("special")
+                .RegisterInstance<ILogger>("instance", l);
+
+            var loggers = container.ResolveAll<ILogger>().ToList();
+
+            Assert.AreEqual(3, loggers.Count);
+            Assert.IsInstanceOfType(loggers[0], typeof(MockLogger));
+            Assert.IsInstanceOfType(loggers[1], typeof(SpecialLogger));
+            Assert.AreSame(l, loggers[2]);
+        }
+
+        [TestMethod]
+        public void CanRegisterLifetimeAsSingleton()
+        {
+            var container = new UnityContainer()
+                .RegisterType<ILogger, MockLogger>()
+                .RegisterType<ILogger, SpecialLogger>("special", new ContainerControlledLifetimeManager());
+
+            var logger1 = container.Resolve<ILogger>();
+            var logger2 = container.Resolve<ILogger>();
+            var logger3 = container.Resolve<ILogger>("special");
+            var logger4 = container.Resolve<ILogger>("special");
+
+            Assert.AreNotSame(logger1, logger2);
+            Assert.AreSame(logger3, logger4);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ResolutionFailedException))]
+        public void ShouldThrowIfAttemptsToResolveUnregisteredInterface()
+        {
+            var container = new UnityContainer();
+            container.Resolve<ILogger>();
+        }
+
+        [TestMethod]
+        public void CanBuildSameTypeTwice()
+        {
+            var container = new UnityContainer();
+
+            container.Resolve<ObjectWithTwoConstructorDependencies>();
+            container.Resolve<ObjectWithTwoConstructorDependencies>();
+        }
+
+        [TestMethod]
+        public void CanRegisterMultipleStringInstances()
+        {
+            var container = new UnityContainer();
+            string first = "first";
+            string second = "second";
+
+            container
+                .RegisterInstance<string>(first)
+                .RegisterInstance<string>(second);
+
+            var result = container.Resolve<string>();
+
+            Assert.AreEqual(second, result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GetReasonableExceptionWhenRegisteringNullInstance()
+        {
+            var container = new UnityContainer();
+            container.RegisterInstance<SomeType>(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void RegisteringTheSameLifetimeManagerTwiceThrows()
+        {
+            var singleton = new ContainerControlledLifetimeManager();
+
+            new UnityContainer()
+                .RegisterType<ILogger, MockLogger>(singleton)
+                .RegisterType<ILogger, SpecialLogger>("special", singleton);
+        }
+
+        [TestMethod]
+        public void CanRegisterGenericTypesAndResolveThem()
+        {
+            var myDict = new Dictionary<string, string>();
+            myDict.Add("One", "two");
+            myDict.Add("Two", "three");
+
+            var container = new UnityContainer()
+                .RegisterInstance(myDict)
+                .RegisterType(typeof(IDictionary<,>), typeof(Dictionary<,>));
+
+            var result = container.Resolve<IDictionary<string, string>>();
+            Assert.AreSame(myDict, result);
+        }
+
+        [TestMethod]
+        public void CanSpecializeGenericsViaTypeMappings()
+        {
+            var container = new UnityContainer()
+                .RegisterType(typeof(IRepository<>), typeof(MockRespository<>))
+                .RegisterType<IRepository<SomeType>, SomeTypRepository>();
+
+            var generalResult = container.Resolve<IRepository<string>>();
+            var specializedResult = container.Resolve<IRepository<SomeType>>();
+
+            Assert.IsInstanceOfType(generalResult, typeof(MockRespository<string>));
+            Assert.IsInstanceOfType(specializedResult, typeof(SomeTypRepository));
+        }
+
+        [TestMethod]
+        public void ContainerResolvesItself()
+        {
+            var container = new UnityContainer();
+
+            Assert.AreSame(container, container.Resolve<IUnityContainer>());
+        }
+
+        [TestMethod]
+        public void ContainerResolvesItselfEvenAfterGarbageCollect()
+        {
+            var container = new UnityContainer();
+            container.AddNewExtension<GarbageCollectingExtension>();
+
+            Assert.IsNotNull(container.Resolve<IUnityContainer>());
+        }
+
+        public class GarbageCollectingExtension : UnityContainerExtension
+        {
+            protected override void Initialize()
+            {
+                this.Context.Strategies.Add(new GarbageCollectingStrategy(), UnityBuildStage.Setup);
+            }
+
+            public class GarbageCollectingStrategy : BuilderStrategy
+            {
+                public override void PreBuildUp(IBuilderContext context)
+                {
+                    GC.Collect();
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ChildContainerResolvesChildNotParent()
+        {
+            var parent = new UnityContainer();
+            var child = parent.CreateChildContainer();
+
+            Assert.AreSame(child, child.Resolve<IUnityContainer>());
+        }
+
+        [TestMethod]
+        public void ParentContainerResolvesParentNotChild()
+        {
+            var parent = new UnityContainer();
+            var child = parent.CreateChildContainer();
+
+            Assert.AreSame(parent, parent.Resolve<IUnityContainer>());
+
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ResolutionFailedException))]
+        public void ResolvingOpenGenericGivesInnerInvalidOperationException()
+        {
+            var container = new UnityContainer()
+                .RegisterType(typeof(List<>), new InjectionConstructor(10));
+
+            try
+            {
+                container.Resolve(typeof (List<>));
+            }
+            catch (ResolutionFailedException e)
+            {
+                Assert.IsInstanceOfType(e.InnerException, typeof(ArgumentException));
+                throw;
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ResolutionFailedException))]
+        public void ResovingObjectWithPrivateSetterGivesUsefulException()
+        {
+            IUnityContainer container = new UnityContainer();
+            try
+            {
+                container.Resolve<ObjectWithPrivateSetter>();
+            }
+            catch (ResolutionFailedException e)
+            {
+                Assert.IsInstanceOfType(e.InnerException, typeof(InvalidOperationException));
+                throw;
+            }
+        }
+
+        [TestMethod]
+        public void ResolvingUnconfiguredPrimitiveDependencyGivesReasonableException()
+        {
+            ResolvingUnconfiguredPrimitiveGivesResonableException<string>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<bool>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<char>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<float>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<double>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<byte>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<short>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<int>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<long>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<IntPtr>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<UIntPtr>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<ushort>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<uint>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<ulong>();
+            ResolvingUnconfiguredPrimitiveGivesResonableException<sbyte>();
+        }
+
+        private void ResolvingUnconfiguredPrimitiveGivesResonableException<T>()
+        {
+            var container = new UnityContainer();
+            try
+            {
+                container.Resolve<TypeWithPrimitiveDependency<T>>();
+            }
+            catch (ResolutionFailedException e)
+            {
+                Assert.IsInstanceOfType(e.InnerException, typeof(InvalidOperationException));
+                return;
+            }
+            Assert.Fail("Expected exception did not occur");
+        }
+
+        internal class SomeType
+        {
+        }
+
+        public interface IRepository<TEntity>
+        {
+        }
+
+        public class MockRespository<TEntity> : IRepository<TEntity>
+        {
+        }
+
+        public class SomeTypRepository : IRepository<SomeType>
+        {
+        }
+
+        public class ObjectWithPrivateSetter
+        {
+            [Dependency]
+            public object Obj1 { get; private set; }
+        }
+
+        public class TypeWithPrimitiveDependency<T>
+        {
+            public TypeWithPrimitiveDependency(T dependency)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
…nsistent with policies). Changed `GetDynamicRegistration` to use parent only if it actually contains the registration. Fixes #108 .