### PR TITLE
Reduce allocations when resolving object and disposing container

### DIFF
--- a/src/Builder/BuilderContext.cs
+++ b/src/Builder/BuilderContext.cs
@@ -39,7 +39,6 @@ namespace Unity.Builder
             Registration = registration;
             OriginalBuildKey = registration;
             BuildKey = OriginalBuildKey;
-            Policies = new Storage.PolicyList(this);
 
             _ownsOverrides = true;
             if (null != resolverOverrides && 0 < resolverOverrides.Length)
@@ -56,7 +55,7 @@ namespace Unity.Builder
             OriginalBuildKey = original.OriginalBuildKey;
             BuildKey = original.BuildKey;
             Registration = original.Registration;
-            Policies = original.Policies;
+            _policies = original.Policies;
             Existing = existing;
             _ownsOverrides = true;
         }
@@ -71,7 +70,7 @@ namespace Unity.Builder
             _ownsOverrides = false;
             ParentContext = original;
             Existing = null;
-            Policies = parent.Policies;
+            _policies = parent.Policies;
             Registration = registration;
             OriginalBuildKey = (INamedType)Registration;
             BuildKey = OriginalBuildKey;
@@ -88,7 +87,7 @@ namespace Unity.Builder
             _ownsOverrides = false;
             ParentContext = original;
             Existing = null;
-            Policies = parent.Policies;
+            _policies = parent.Policies;
             Registration = registration;
             OriginalBuildKey = registration;
             BuildKey = OriginalBuildKey;
@@ -113,7 +112,8 @@ namespace Unity.Builder
 
         public IPolicySet Registration { get; }
 
-        public IPolicyList Policies { get; private set; }
+        private IPolicyList _policies;
+        public IPolicyList Policies => _policies ?? (_policies = new Storage.PolicyList(this));
 
         public IRequiresRecovery RequiresRecovery { get; set; }
 

--- a/src/UnityContainer.Implementation.cs
+++ b/src/UnityContainer.Implementation.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Unity.Builder;
 using Unity.Builder.Strategy;
 using Unity.Container;
@@ -382,9 +381,10 @@ namespace Unity
 
             if (null != _extensions)
             {
-                foreach (IDisposable disposable in _extensions.OfType<IDisposable>()
-                                                              .ToList())
+                foreach (var extention in _extensions)
                 {
+                    if(!(extention is IDisposable disposable)) continue;
+
                     try
                     {
                         disposable.Dispose();

--- a/tests/Performance/Tests/ChildContainer.cs
+++ b/tests/Performance/Tests/ChildContainer.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using Runner.Tests;
+using Unity;
+using Unity.Lifetime;
+
+namespace Performance.Tests
+{
+    [BenchmarkCategory("ChildContainer")]
+    [MemoryDiagnoser]
+    public class ChildContainer
+    {
+        private IUnityContainer _container;
+
+        [Params(1, 2, 3, 4, 10, 50, 100)] public int Resolves;
+
+        [GlobalSetup]
+        public void SetupContainer()
+        {
+            _container = new UnityContainer();
+            _container.RegisterType<Poco>();
+            _container.RegisterType<IService, Service>();
+            _container.RegisterType<IService, Service>("1");
+            _container.RegisterType<IService, Service>("2");
+
+            for (var i = 0; i < 100; i++)
+                _container.RegisterType<DisposableObject>(i.ToString(), new HierarchicalLifetimeManager());
+        }
+
+        [Benchmark(Baseline = true)]
+        public void CreateChildContainer()
+        {
+            using (_container.CreateChildContainer())
+            {
+            }
+        }
+
+        //[Benchmark]
+        //public void ChildTransient()
+        //{
+        //    using (var child = _container.CreateChildContainer())
+        //    {
+        //        for (var i = 0; i < Resolves; i++)
+        //            child.Resolve(typeof(Poco), null);
+        //    }
+        //}
+
+        //[Benchmark]
+        //public void ChildMapping()
+        //{
+        //    using (var child = _container.CreateChildContainer())
+        //    {
+        //        for (var i = 0; i < Resolves; i++)
+        //            child.Resolve(typeof(IService), null);
+        //    }
+        //}
+
+        //[Benchmark]
+        //public void ChildArray()
+        //{
+        //    using (var child = _container.CreateChildContainer())
+        //    {
+        //        for (var i = 0; i < Resolves; i++)
+        //            child.Resolve(typeof(IService[]), null);
+        //    }
+        //}
+
+        //[Benchmark]
+        //public void ChildEnumerable()
+        //{
+        //    using (var child = _container.CreateChildContainer())
+        //    {
+        //        for (var i = 0; i < Resolves; i++)
+        //            child.Resolve(typeof(IEnumerable<IService>), null);
+        //    }
+        //}
+
+        [Benchmark]
+        public void ChildDisposableObject()
+        {
+            using (var child = _container.CreateChildContainer())
+            {
+                for (var i = 0; i < Resolves; i++)
+                    child.Resolve<DisposableObject>(i.ToString());
+            }
+        }
+
+
+        private class DisposableObject : IDisposable
+        {
+            public bool WasDisposed = false;
+
+            public virtual void Dispose()
+            {
+                WasDisposed = true;
+            }
+        }
+    }
+}

--- a/tests/Performance/Tests/Resolution.cs
+++ b/tests/Performance/Tests/Resolution.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Runner.Tests;
+using Unity;
+
+namespace Performance.Tests
+{
+    [BenchmarkCategory("Resolution")]
+    [MemoryDiagnoser]
+    public class Resolution
+    {
+        private IUnityContainer _container;
+
+        [GlobalSetup]
+        public void SetupContainer()
+        {
+            _container = new UnityContainer();
+            _container.RegisterType<Poco>();
+            _container.RegisterType<IService, Service>();
+            _container.RegisterType<IService, Service>("1");
+            _container.RegisterType<IService, Service>("2");
+        }
+
+        [Benchmark(Baseline = true)]
+        public object Container() => _container.Resolve(typeof(IUnityContainer), null);
+
+        [Benchmark]
+        public object Unregistered() => _container.Resolve(typeof(object), null);
+
+        [Benchmark]
+        public object Transient() => _container.Resolve(typeof(Poco), null);
+
+        [Benchmark]
+        public object Mapping() => _container.Resolve(typeof(IService), null);
+
+        [Benchmark]
+        public object Array() => _container.Resolve(typeof(IService[]), null);
+
+        [Benchmark]
+        public object Enumerable() => _container.Resolve(typeof(IEnumerable<IService>), null);
+    }
+}


### PR DESCRIPTION
Benchmark data for reducing Resolve allocations:

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17134.407 (1803/April2018Update/Redstone4)
Intel Core i7-4770 CPU 3.40GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3221.0
  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3221.0


Before:
       Method   |       Mean |     Error |    StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
-------------    |-----------:|----------:|----------:|-------:|---------:|-------:|----------:|
    Container   |   154.1 ns | 0.8584 ns | 0.7168 ns |   1.00 |     0.00 | 0.0551 |     232 B |
 Unregistered |   166.5 ns | 1.2328 ns | 1.0928 ns |   1.08 |     0.01 | 0.0684 |     288 B |
    Transient    |   184.9 ns | 1.8760 ns | 1.7548 ns |   1.20 |     0.01 | 0.0684 |     288 B |
      Mapping  |   185.7 ns | 3.5893 ns | 4.4080 ns |   1.21 |     0.03 | 0.0684 |     288 B |
        Array      |   903.6 ns | 3.9871 ns | 3.5344 ns |   5.86 |     0.03 | 0.4015 |    1688 B |
   Enumerable| 1,031.9 ns | 8.7696 ns | 7.7740 ns |   6.70 |     0.06 | 0.4330 |    1824 B |

After:
       Method    |       Mean |    Error |    StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
-------------     |-----------:|---------:|----------:|-------:|---------:|-------:|----------:|
    Container    |   157.6 ns | 1.823 ns | 1.6164 ns |   1.00 |     0.00 | 0.0551 |     232 B |
 Unregistered  |   153.4 ns | 2.962 ns | 4.0548 ns |   0.97 |     0.03 | 0.0532 |     224 B |
    Transient     |   167.0 ns | 1.142 ns | 0.8916 ns |   1.06 |     0.01 | 0.0532 |     224 B |
      Mapping   |   169.0 ns | 2.024 ns | 1.8928 ns |   1.07 |     0.02 | 0.0532 |     224 B |
        Array       |   911.4 ns | 7.797 ns | 6.0872 ns |   5.78 |     0.07 | 0.4015 |    1688 B |
   Enumerable | 1,022.0 ns | 5.905 ns | 4.9309 ns |   6.49 |     0.07 | 0.4330 |    1824 B |


Benchmark data for reducing allocations when disposing container:

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17134.407 (1803/April2018Update/Redstone4)
Intel Core i7-4770 CPU 3.40GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3221.0
  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3221.0

Before:
                Method      | Resolves |       Mean |     Error |    StdDev | Scaled | ScaledSD |   Gen 0 | Allocated |
----------------------     |--------- |-----------:|----------:|----------:|-------:|---------:|--------:|----------:|
  CreateChildContainer  |        1 |   9.974 us | 0.1953 us | 0.2608 us |   1.00 |     0.00 |  0.3204 |   1.37 KB |
 ChildDisposableObject |        1 |  11.210 us | 0.1239 us | 0.0967 us |   1.12 |     0.03 |  0.4883 |   2.02 KB |

  CreateChildContainer  |        2 |   9.887 us | 0.2010 us | 0.1782 us |   1.00 |     0.00 |  0.3204 |   1.37 KB |
 ChildDisposableObject |        2 |  12.408 us | 0.2468 us | 0.3769 us |   1.26 |     0.04 |  0.5951 |    2.5 KB |

  CreateChildContainer  |        3 |   9.853 us | 0.1176 us | 0.1043 us |   1.00 |     0.00 |  0.3204 |   1.37 KB |
 ChildDisposableObject |        3 |  13.285 us | 0.2689 us | 0.4779 us |   1.35 |     0.05 |  0.7172 |   2.98 KB |

  CreateChildContainer  |        4 |   9.767 us | 0.0344 us | 0.0321 us |   1.00 |     0.00 |  0.3204 |   1.37 KB |
 ChildDisposableObject |        4 |  13.673 us | 0.0788 us | 0.0737 us |   1.40 |     0.01 |  0.8240 |   3.41 KB |

  CreateChildContainer  |       10 |   9.768 us | 0.0684 us | 0.0534 us |   1.00 |     0.00 |  0.3204 |   1.37 KB |
 ChildDisposableObject |       10 |  19.798 us | 0.2412 us | 0.2257 us |   2.03 |     0.02 |  1.8005 |   7.42 KB |

  CreateChildContainer  |       50 |   9.806 us | 0.0865 us | 0.0675 us |   1.00 |     0.00 |  0.3204 |   1.37 KB |
 ChildDisposableObject |       50 |  59.914 us | 1.1849 us | 1.6611 us |   6.11 |     0.17 |  7.5684 |  31.13 KB |

  CreateChildContainer  |      100 |   9.737 us | 0.0272 us | 0.0227 us |   1.00 |     0.00 |  0.3204 |   1.37 KB |
 ChildDisposableObject |      100 | 109.031 us | 0.6636 us | 0.6207 us |  11.20 |     0.07 | 14.7705 |  60.95 KB |



After:

                Method    | Resolves |       Mean |     Error |    StdDev |     Median | Scaled | ScaledSD |   Gen 0 | Allocated |
---------------------- |--------- |-----------:|----------:|----------:|-----------:|-------:|---------:|--------:|----------:|
  CreateChildContainer |        1 |   9.425 us | 0.0702 us | 0.0622 us |   9.420 us |   1.00 |     0.00 |  0.1984 |     848 B |
 ChildDisposableObject |        1 |  10.709 us | 0.2124 us | 0.4572 us |  10.520 us |   1.14 |     0.05 |  0.3357 |    1424 B |

  CreateChildContainer |        2 |   9.464 us | 0.0933 us | 0.0779 us |   9.482 us |   1.00 |     0.00 |  0.1984 |     848 B |
 ChildDisposableObject |        2 |  11.191 us | 0.1372 us | 0.1284 us |  11.156 us |   1.18 |     0.02 |  0.4425 |    1920 B |

  CreateChildContainer |        3 |   9.417 us | 0.1240 us | 0.1035 us |   9.377 us |   1.00 |     0.00 |  0.1984 |     848 B |
 ChildDisposableObject |        3 |  11.899 us | 0.0736 us | 0.0575 us |  11.882 us |   1.26 |     0.01 |  0.5646 |    2416 B |

  CreateChildContainer |        4 |   9.520 us | 0.1572 us | 0.1227 us |   9.521 us |   1.00 |     0.00 |  0.1984 |     848 B |
 ChildDisposableObject |        4 |  13.105 us | 0.2897 us | 0.6714 us |  12.805 us |   1.38 |     0.07 |  0.6866 |    2912 B |

  CreateChildContainer |       10 |   9.499 us | 0.1484 us | 0.1388 us |   9.483 us |   1.00 |     0.00 |  0.1984 |     848 B |
 ChildDisposableObject |       10 |  17.233 us | 0.1032 us | 0.0915 us |  17.227 us |   1.81 |     0.03 |  1.4343 |    6128 B |

  CreateChildContainer |       50 |   9.494 us | 0.1049 us | 0.0876 us |   9.462 us |   1.00 |     0.00 |  0.1984 |     848 B |
 ChildDisposableObject |       50 |  54.313 us | 1.1396 us | 2.4038 us |  53.255 us |   5.72 |     0.26 |  6.3477 |   26785 B |

  CreateChildContainer |      100 |   9.491 us | 0.1870 us | 0.2001 us |   9.392 us |   1.00 |     0.00 |  0.1984 |     848 B |
 ChildDisposableObject |      100 | 107.729 us | 2.4862 us | 3.3190 us | 106.016 us |  11.35 |     0.41 | 12.4512 |   52633 B |
