### PR TITLE
Reduce allocations when resolving object and disposing container

### DIFF
--- a/src/Builder/BuilderContext.cs
+++ b/src/Builder/BuilderContext.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
-using Unity.Build;
 using Unity.Builder.Strategy;
 using Unity.Container;
 using Unity.Delegates;
@@ -42,7 +41,6 @@ namespace Unity.Builder
             OriginalBuildKey = registration;
             BuildKey = OriginalBuildKey;
             TypeInfo = BuildKey.Type.GetTypeInfo();
-            Policies = new PolicyList(this);
 
             if (null != resolverOverrides && 0 < resolverOverrides.Length)
                 _resolverOverrides = resolverOverrides;
@@ -57,7 +55,7 @@ namespace Unity.Builder
             BuildKey = original.BuildKey;
             TypeInfo = BuildKey.Type.GetTypeInfo();
             Registration = original.Registration;
-            Policies = original.Policies;
+            _policies = original.Policies;
             Existing = existing;
         }
 
@@ -70,7 +68,7 @@ namespace Unity.Builder
             _resolverOverrides = parent._resolverOverrides;
             ParentContext = original;
             Existing = null;
-            Policies = parent.Policies;
+            _policies = parent.Policies;
             Registration = registration;
             OriginalBuildKey = (INamedType)Registration;
             BuildKey = OriginalBuildKey;
@@ -87,7 +85,7 @@ namespace Unity.Builder
             _resolverOverrides = parent._resolverOverrides;
             ParentContext = original;
             Existing = null;
-            Policies = parent.Policies;
+            _policies = parent.Policies;
             Registration = registration;
             OriginalBuildKey = registration;
             BuildKey = OriginalBuildKey;
@@ -244,7 +242,8 @@ namespace Unity.Builder
 
         public IPolicySet Registration { get; }
 
-        public IPolicyList Policies { get; }
+        private IPolicyList _policies;
+        public IPolicyList Policies => _policies ?? (_policies = new PolicyList(this));
 
         public IRequiresRecovery RequiresRecovery { get; set; }
 

--- a/src/UnityContainer.Implementation.cs
+++ b/src/UnityContainer.Implementation.cs
@@ -356,9 +356,10 @@ namespace Unity
 
             if (null != _extensions)
             {
-                foreach (IDisposable disposable in _extensions.OfType<IDisposable>()
-                                                              .ToList())
+                foreach (var extention in _extensions)
                 {
+                    if(!(extention is IDisposable disposable)) continue;
+
                     try
                     {
                         disposable.Dispose();

--- a/tests/Performance/Tests/ChildContainer.cs
+++ b/tests/Performance/Tests/ChildContainer.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using Runner.Tests;
+using Unity;
+using Unity.Lifetime;
+
+namespace Performance.Tests
+{
+    [BenchmarkCategory("ChildContainer")]
+    [MemoryDiagnoser]
+    public class ChildContainer
+    {
+        private IUnityContainer _container;
+
+        [Params(1, 2, 3, 4, 10, 50, 100)] public int Resolves;
+
+        [GlobalSetup]
+        public void SetupContainer()
+        {
+            _container = new UnityContainer();
+            _container.RegisterType<Poco>();
+            _container.RegisterType<IService, Service>();
+            _container.RegisterType<IService, Service>("1");
+            _container.RegisterType<IService, Service>("2");
+
+            for (var i = 0; i < 100; i++)
+                _container.RegisterType<DisposableObject>(i.ToString(), new HierarchicalLifetimeManager());
+        }
+
+        [Benchmark(Baseline = true)]
+        public void CreateChildContainer()
+        {
+            using (_container.CreateChildContainer())
+            {
+            }
+        }
+
+        //[Benchmark]
+        //public void ChildTransient()
+        //{
+        //    using (var child = _container.CreateChildContainer())
+        //    {
+        //        for (var i = 0; i < Resolves; i++)
+        //            child.Resolve(typeof(Poco), null);
+        //    }
+        //}
+
+        //[Benchmark]
+        //public void ChildMapping()
+        //{
+        //    using (var child = _container.CreateChildContainer())
+        //    {
+        //        for (var i = 0; i < Resolves; i++)
+        //            child.Resolve(typeof(IService), null);
+        //    }
+        //}
+
+        //[Benchmark]
+        //public void ChildArray()
+        //{
+        //    using (var child = _container.CreateChildContainer())
+        //    {
+        //        for (var i = 0; i < Resolves; i++)
+        //            child.Resolve(typeof(IService[]), null);
+        //    }
+        //}
+
+        //[Benchmark]
+        //public void ChildEnumerable()
+        //{
+        //    using (var child = _container.CreateChildContainer())
+        //    {
+        //        for (var i = 0; i < Resolves; i++)
+        //            child.Resolve(typeof(IEnumerable<IService>), null);
+        //    }
+        //}
+
+        [Benchmark]
+        public void ChildDisposableObject()
+        {
+            using (var child = _container.CreateChildContainer())
+            {
+                for (var i = 0; i < Resolves; i++)
+                    child.Resolve<DisposableObject>(i.ToString());
+            }
+        }
+
+
+        private class DisposableObject : IDisposable
+        {
+            public bool WasDisposed = false;
+
+            public virtual void Dispose()
+            {
+                WasDisposed = true;
+            }
+        }
+    }
+}

--- a/tests/Performance/Tests/Resolution.cs
+++ b/tests/Performance/Tests/Resolution.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Runner.Tests;
+using Unity;
+
+namespace Performance.Tests
+{
+    [BenchmarkCategory("Resolution")]
+    [MemoryDiagnoser]
+    public class Resolution
+    {
+        private IUnityContainer _container;
+
+        [GlobalSetup]
+        public void SetupContainer()
+        {
+            _container = new UnityContainer();
+            _container.RegisterType<Poco>();
+            _container.RegisterType<IService, Service>();
+            _container.RegisterType<IService, Service>("1");
+            _container.RegisterType<IService, Service>("2");
+        }
+
+        [Benchmark(Baseline = true)]
+        public object Container() => _container.Resolve(typeof(IUnityContainer), null);
+
+        [Benchmark]
+        public object Unregistered() => _container.Resolve(typeof(object), null);
+
+        [Benchmark]
+        public object Transient() => _container.Resolve(typeof(Poco), null);
+
+        [Benchmark]
+        public object Mapping() => _container.Resolve(typeof(IService), null);
+
+        [Benchmark]
+        public object Array() => _container.Resolve(typeof(IService[]), null);
+
+        [Benchmark]
+        public object Enumerable() => _container.Resolve(typeof(IEnumerable<IService>), null);
+    }
+}


### PR DESCRIPTION
Benchmark data for reducing Resolve allocations:

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17134.407 (1803/April2018Update/Redstone4)
Intel Core i7-4770 CPU 3.40GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3221.0
  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3221.0

Before:

       Method  |       Mean |     Error |    StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
-------------   |----------- :|----------:|----------:|-------:|---------:|-------:|----------:|
    Container   |    188.6 ns |  3.834 ns |  9.477 ns |   1.00 |     0.00 | 0.0570 |     240 B |
 Unregistered |    197.9 ns |  3.901 ns |  6.935 ns |   1.05 |     0.06 | 0.0627 |     264 B |
    Transient    |    217.3 ns |  4.261 ns |  5.389 ns |   1.15 |     0.06 | 0.0627 |     264 B |
      Mapping  |    397.0 ns |  8.708 ns | 16.985 ns |   2.11 |     0.14 | 0.0625 |     264 B |
        Array      | 1,359.5 ns | 27.178 ns | 32.353 ns |   7.22 |     0.40 | 0.3910 |    1648 B |
   Enumerable| 1,702.5 ns | 32.853 ns | 48.155 ns |   9.05 |     0.52 | 0.4177 |    1760 B |

After:

       Method |       Mean |     Error |    StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
------------- |-----------:|----------:|----------:|-------:|---------:|-------:|----------:|
    Container   |   181.0 ns |  3.338 ns |  3.123 ns |   1.00 |     0.00 | 0.0570 |     240 B |
 Unregistered |   175.2 ns |  2.181 ns |  1.821 ns |   0.97 |     0.02 | 0.0474 |     200 B |
    Transient    |   192.4 ns |  2.845 ns |  2.522 ns |   1.06 |     0.02 | 0.0474 |     200 B |
      Mapping  |   357.4 ns |  7.064 ns | 12.738 ns |   1.97 |     0.08 | 0.0472 |     200 B |
        Array     | 1,355.0 ns | 27.050 ns | 69.338 ns |   7.49 |     0.40 | 0.3910 |    1648 B |
   Enumerable  1,615.7 ns | 32.097 ns | 34.343 ns |   8.93 |     0.24 | 0.4177 |    1760 B |

Benchmark data for reducing allocations when disposing container:

Before:

                Method | Resolves |       Mean |     Error |    StdDev | Scaled | ScaledSD |   Gen 0 | Allocated |
---------------------- |--------- |-----------:|----------:|----------:|-------:|---------:|--------:|----------:|
  CreateChildContainer |        1 |   1.881 us | 0.0327 us | 0.0306 us |   1.00 |     0.00 |  0.3300 |   1.36 KB |
 ChildDisposableObject |       1 |   3.247 us | 0.0636 us | 0.0624 us |   1.73 |     0.04 |  0.4807 |   1.98 KB |
  CreateChildContainer |        2 |   1.884 us | 0.0371 us | 0.0544 us |   1.00 |     0.00 |  0.3281 |   1.36 KB |
 ChildDisposableObject |       2 |   4.283 us | 0.0849 us | 0.1573 us |   2.28 |     0.10 |  0.5951 |   2.45 KB |
  CreateChildContainer |        3 |   1.890 us | 0.0376 us | 0.0885 us |   1.00 |     0.00 |  0.3300 |   1.36 KB |
 ChildDisposableObject |       3 |   5.332 us | 0.1034 us | 0.0967 us |   2.83 |     0.14 |  0.7019 |   2.91 KB |
  CreateChildContainer |        4 |   1.872 us | 0.0370 us | 0.0468 us |   1.00 |     0.00 |  0.3281 |   1.36 KB |
 ChildDisposableObject |       4 |   6.282 us | 0.0884 us | 0.0827 us |   3.36 |     0.09 |  0.8011 |   3.31 KB |
  CreateChildContainer |       10 |   1.906 us | 0.0406 us | 0.0791 us |   1.00 |     0.00 |  0.3281 |   1.36 KB |
 ChildDisposableObject |      10 |  12.944 us | 0.2506 us | 0.3258 us |   6.80 |     0.32 |  1.7395 |   7.18 KB |
  CreateChildContainer |       50 |   1.886 us | 0.0373 us | 0.0399 us |   1.00 |     0.00 |  0.3300 |   1.36 KB |
 ChildDisposableObject |      50 |  57.378 us | 0.9161 us | 0.8569 us |  30.43 |     0.77 |  7.2632 |  29.95 KB |
  CreateChildContainer |      100 |   1.854 us | 0.0352 us | 0.0406 us |   1.00 |     0.00 |  0.3281 |   1.36 KB |
 ChildDisposableObject |     100 | 112.166 us | 1.9516 us | 1.8255 us |  60.51 |     1.60 | 14.2822 |   58.6 KB |

After:

                Method | Resolves |       Mean |     Error |    StdDev | Scaled | ScaledSD |   Gen 0 | Allocated |
---------------------- |--------- |-----------:|----------:|----------:|-------:|---------:|--------:|----------:|
  CreateChildContainer |        1 |   1.483 us | 0.0293 us | 0.0430 us |   1.00 |     0.00 |  0.1984 |     840 B |
 ChildDisposableObject |       1 |   2.460 us | 0.0450 us | 0.0351 us |   1.66 |     0.05 |  0.3281 |    1392 B |
  CreateChildContainer |        2 |   1.447 us | 0.0207 us | 0.0173 us |   1.00 |     0.00 |  0.1984 |     840 B |
 ChildDisposableObject |       2 |   3.186 us | 0.0630 us | 0.0619 us |   2.20 |     0.05 |  0.4425 |    1864 B |
  CreateChildContainer |        3 |   1.504 us | 0.0315 us | 0.0664 us |   1.00 |     0.00 |  0.1984 |     840 B |
 ChildDisposableObject |       3 |   4.200 us | 0.0833 us | 0.2323 us |   2.80 |     0.19 |  0.5493 |    2336 B |
  CreateChildContainer |        4 |   1.459 us | 0.0285 us | 0.0305 us |   1.00 |     0.00 |  0.1984 |     840 B |
 ChildDisposableObject |       4 |   5.138 us | 0.1209 us | 0.1614 us |   3.52 |     0.13 |  0.6638 |    2808 B |
  CreateChildContainer |       10 |   1.482 us | 0.0294 us | 0.0523 us |   1.00 |     0.00 |  0.1984 |     840 B |
 ChildDisposableObject |      10 |  10.487 us | 0.2082 us | 0.3858 us |   7.08 |     0.36 |  1.3885 |    5880 B |
  CreateChildContainer |       50 |   1.458 us | 0.0288 us | 0.0465 us |   1.00 |     0.00 |  0.1984 |     840 B |
 ChildDisposableObject |      50 |  49.195 us | 0.9668 us | 1.7678 us |  33.78 |     1.59 |  6.0425 |   25577 B |
  CreateChildContainer |      100 |   1.517 us | 0.0283 us | 0.0251 us |   1.00 |     0.00 |  0.1984 |     840 B |
 ChildDisposableObject |     100 | 108.263 us | 2.1414 us | 3.6938 us |  71.38 |     2.66 | 11.9629 |   50226 B |