### PR TITLE
Fixed hash code collisions and circular references in HashRegistry, Registrations

### DIFF
--- a/src/Storage/HashRegistry.cs
+++ b/src/Storage/HashRegistry.cs
@@ -151,19 +151,19 @@ namespace Unity.Storage
             for (var i = Buckets[targetBucket]; i >= 0; i = Entries[i].Next)
             {
                 ref var candidate = ref Entries[i];
-                if (candidate.HashCode != hashCode || Equals(candidate.Key, key)) continue;
+                if (candidate.HashCode != hashCode || !Equals(candidate.Key, key)) continue;
 
                 return candidate.Value;
             }
 
             var value = factory();
             ref var entry = ref Entries[Count];
-            Buckets[targetBucket] = Count++;
 
             entry.HashCode = hashCode;
             entry.Next = Buckets[targetBucket];
             entry.Key = key;
             entry.Value = value;
+            Buckets[targetBucket] = Count++;
 
             return value;
         }
@@ -175,7 +175,7 @@ namespace Unity.Storage
             for (var i = Buckets[targetBucket]; i >= 0; i = Entries[i].Next)
             {
                 ref var candidate = ref Entries[i];
-                if (candidate.HashCode != hashCode || Equals(candidate.Key, key)) continue;
+                if (candidate.HashCode != hashCode || !Equals(candidate.Key, key)) continue;
 
                 var old = candidate.Value;
                 candidate.Value = value;

--- a/src/Storage/Registrations.cs
+++ b/src/Storage/Registrations.cs
@@ -145,19 +145,19 @@ namespace Unity.Storage
             for (var i = Buckets[targetBucket]; i >= 0; i = Entries[i].Next)
             {
                 ref var candidate = ref Entries[i];
-                if (candidate.HashCode != hashCode || Equals(candidate.Key, key)) continue;
+                if (candidate.HashCode != hashCode || !Equals(candidate.Key, key)) continue;
 
                 return candidate.Value;
             }
 
             var value = factory();
             ref var entry = ref Entries[Count];
-            Buckets[targetBucket] = Count++;
 
             entry.HashCode = hashCode;
             entry.Next = Buckets[targetBucket];
             entry.Key = key;
             entry.Value = value;
+            Buckets[targetBucket] = Count++;
 
             return value;
         }
@@ -169,7 +169,7 @@ namespace Unity.Storage
             for (var i = Buckets[targetBucket]; i >= 0; i = Entries[i].Next)
             {
                 ref var candidate = ref Entries[i];
-                if (candidate.HashCode != hashCode || Equals(candidate.Key, key)) continue;
+                if (candidate.HashCode != hashCode || !Equals(candidate.Key, key)) continue;
 
                 var old = candidate.Value;
                 candidate.Value = value;


### PR DESCRIPTION
Fixed comparison for key hash code collisions.
Fixed circular references in Entries when several entries are placed in the same bucket.