### PR TITLE
Removed unsafe code in NET40

### DIFF
--- a/src/Storage/HashRegistry.cs
+++ b/src/Storage/HashRegistry.cs
@@ -35,15 +35,20 @@ namespace Unity.Storage
             Buckets = new int[size];
             Entries = new Entry[size];
 
+#if !NET40
             unsafe
             {
                 fixed (int* bucketsPtr = Buckets)
                 {
                     int* ptr = bucketsPtr;
                     var end = bucketsPtr + Buckets.Length;
-                    while (ptr < end) *ptr++ = -1; 
+                    while (ptr < end) *ptr++ = -1;
                 }
             }
+#else
+            for(int i = 0; i < Buckets.Length; i++)
+                Buckets[i] = -1;
+#endif
         }
 
         public HashRegistry(int capacity, LinkedNode<string, IPolicySet> head)

--- a/src/Storage/Registrations.cs
+++ b/src/Storage/Registrations.cs
@@ -35,6 +35,7 @@ namespace Unity.Storage
             Buckets = new int[size];
             Entries = new Entry[size];
 
+#if !NET40
             unsafe
             {
                 fixed (int* bucketsPtr = Buckets)
@@ -44,6 +45,10 @@ namespace Unity.Storage
                     while (ptr < end) *ptr++ = -1;
                 }
             }
+#else
+            for(int i = 0; i < Buckets.Length; i++)
+                Buckets[i] = -1;
+#endif
         }
 
         public Registrations(int capacity, LinkedNode<Type, IRegistry<string, IPolicySet>> head)


### PR DESCRIPTION
As discussed in #137 I've replaced the unsafe code with a for loop for `NET40`. This enables the NET40 Assemblies to be used in a sandbox with limited permissions (In my case Dynamics 365).

BTW, could you shortly explain me why you are using this unsafe loop here? Is it for performance? When yes, how much of a improvement is this?