### PR TITLE
Updated InternalRegistration Set method to update node if there is an existing node

### DIFF
--- a/src/Registration/InternalRegistration.cs
+++ b/src/Registration/InternalRegistration.cs
@@ -61,6 +61,17 @@ namespace Unity.Registration
             }
             else
             {
+                for (var node = (LinkedNode<Type, object>)this; node != null; node = node.Next)
+                {
+                    if (node.Key == policyInterface)
+                    {
+                        // Found it
+                        node.Value = policy;
+                        return;
+                    }
+                }
+
+                // If not found, insert after the current object
                 Next = new LinkedNode<Type, object>
                 {
                     Key = policyInterface,


### PR DESCRIPTION
Updated InternalRegistration Set method to update node if there is an existing node 
to update node if there is an existing node with the key instead of always inserting.  The
always inserting functionality was causing a memory leak with the
Unity.Interception because the PreBuildUp was always inserting a new
node on every resolve.

I'm not sure that this is the correct fix given the current design but I did verify that it prevents the current memory leak.  