### PR TITLE
Keep stacktrace when rethrowing exceptions

### DIFF
--- a/src/Legacy/DynamicMethod/DynamicBuildPlanGenerationContext.cs
+++ b/src/Legacy/DynamicMethod/DynamicBuildPlanGenerationContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Unity.Builder;
 using Unity.Policy;
 using Unity.Resolution;
@@ -58,7 +59,11 @@ namespace Unity.ObjectBuilder.BuildPlan.DynamicMethod
                 }
                 catch (TargetInvocationException e)
                 {
+#if !NET40
+                    if (e.InnerException != null) ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+#else
                     if (e.InnerException != null) throw e.InnerException;
+#endif
                     throw;
                 }
 

--- a/src/Lifetime/LifetimeContainer.cs
+++ b/src/Lifetime/LifetimeContainer.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 
 namespace Unity.Lifetime
 {
@@ -123,7 +124,11 @@ namespace Unity.Lifetime
 
             if (exceptions.Count == 1)
             {
-                throw exceptions.First();
+#if !NET40
+                ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+#else
+                throw exceptions[0];
+#endif
             }
             else if (exceptions.Count > 1)
             {

--- a/src/Processors/Constructor/ConstructorResolution.cs
+++ b/src/Processors/Constructor/ConstructorResolution.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Unity.Builder;
 using Unity.Exceptions;
 using Unity.Injection;
@@ -42,7 +43,11 @@ namespace Unity.Processors
                     return (ref BuilderContext c) =>
                     {
                         if (null == c.Existing)
+#if !NET40
+                            ExceptionDispatchInfo.Capture(exception).Throw();
+#else
                             throw exception;
+#endif
 
                         return c.Existing;
                     };
@@ -84,10 +89,10 @@ namespace Unity.Processors
             };
         }
 
-        #endregion
+#endregion
 
 
-        #region Implementation
+#region Implementation
 
         protected virtual ResolveDelegate<BuilderContext> GetPerResolveDelegate(ConstructorInfo info, object? data)
         {
@@ -110,6 +115,6 @@ namespace Unity.Processors
             };
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/Processors/Constructor/ConstructorResolution.cs
+++ b/src/Processors/Constructor/ConstructorResolution.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using Unity.Builder;
@@ -89,10 +90,10 @@ namespace Unity.Processors
             };
         }
 
-#endregion
+        #endregion
 
 
-#region Implementation
+        #region Implementation
 
         protected virtual ResolveDelegate<BuilderContext> GetPerResolveDelegate(ConstructorInfo info, object? data)
         {
@@ -115,6 +116,6 @@ namespace Unity.Processors
             };
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/UnityContainer.Implementation.cs
+++ b/src/UnityContainer.Implementation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Unity.Builder;
 using Unity.Events;
 using Unity.Extension;
@@ -416,7 +417,11 @@ namespace Unity
 
             if (null != exceptions && exceptions.Count == 1)
             {
+#if !NET40
+                ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+#else
                 throw exceptions[0];
+#endif
             }
             else if (null != exceptions && exceptions.Count > 1)
             {
@@ -424,10 +429,10 @@ namespace Unity
             }
         }
 
-        #endregion
+#endregion
 
 
-        #region Nested Types
+#region Nested Types
 
         private class RegistrationContext : IPolicyList
         {
@@ -445,7 +450,7 @@ namespace Unity
             }
 
 
-            #region IPolicyList
+#region IPolicyList
 
             public object? Get(Type type, Type policyInterface)
             {
@@ -487,7 +492,7 @@ namespace Unity
                     _registration.Clear(policyInterface);
             }
 
-            #endregion
+#endregion
         }
 
         [DebuggerDisplay("RegisteredType={RegisteredType?.Name},    Name={Name},    MappedTo={RegisteredType == MappedToType ? string.Empty : MappedToType?.Name ?? string.Empty},    {LifetimeManager?.GetType()?.Name}")]
@@ -502,6 +507,6 @@ namespace Unity
             public LifetimeManager LifetimeManager { get; internal set; }
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/UnityContainer.Implementation.cs
+++ b/src/UnityContainer.Implementation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -429,10 +429,10 @@ namespace Unity
             }
         }
 
-#endregion
+        #endregion
 
 
-#region Nested Types
+        #region Nested Types
 
         private class RegistrationContext : IPolicyList
         {
@@ -450,7 +450,7 @@ namespace Unity
             }
 
 
-#region IPolicyList
+            #region IPolicyList
 
             public object? Get(Type type, Type policyInterface)
             {
@@ -492,7 +492,7 @@ namespace Unity
                     _registration.Clear(policyInterface);
             }
 
-#endregion
+            #endregion
         }
 
         [DebuggerDisplay("RegisteredType={RegisteredType?.Name},    Name={Name},    MappedTo={RegisteredType == MappedToType ? string.Empty : MappedToType?.Name ?? string.Empty},    {LifetimeManager?.GetType()?.Name}")]
@@ -507,6 +507,6 @@ namespace Unity
             public LifetimeManager LifetimeManager { get; internal set; }
         }
 
-#endregion
+        #endregion
     }
 }


### PR DESCRIPTION
Rethrowing an exception with **throw** will overwrite the original stack trace.
Rethrowing it using **ExceptionDispatchInfo** will keep the original stack trace.

Fixes https://github.com/unitycontainer/unity/issues/344